### PR TITLE
HTTPBin changed underneath treq

### DIFF
--- a/treq/test/test_treq_integration.py
+++ b/treq/test/test_treq_integration.py
@@ -95,7 +95,7 @@ class TreqIntegrationTests(TestCase):
     def test_get_headers(self):
         response = yield self.get('/get', {'X-Blah': ['Foo', 'Bar']})
         self.assertEqual(response.code, 200)
-        yield self.assert_sent_header(response, 'X-Blah', 'Foo, Bar')
+        yield self.assert_sent_header(response, 'X-Blah', 'Foo,Bar')
         yield print_response(response)
 
     @inlineCallbacks


### PR DESCRIPTION
Treq uses httpbin to test! Unfortunately, it changed how it handled a list of headers, and removed the space (as it should).

This fixes it.